### PR TITLE
Refined Open Weight Handicap 

### DIFF
--- a/app/elo.py
+++ b/app/elo.py
@@ -152,7 +152,7 @@ AGE_K_FACTOR_MODIFIERS = {
 
 # the amount of "ghost rating points" to add to the rating of an athlete in the open class,
 # the index is the difference in weight classes
-WEIGHT_HANDICAPS = [0, 85, 123, 164, 200, 296, 382, 491, 511]
+WEIGHT_HANDICAPS = [0, 54.13, 64.47, 132.21, 168.89, 176.04, 224.28, 372.91, 435.37]
 
 no_match_strings = [
     "Disqualified by no show",


### PR DESCRIPTION
Used Male/Female open weight matches black belt to calculate win percentage. Then added the amount of elo points to offset. Then ran a simulation to see if the matches were performing as expected in reality with the Elo differences, then fine funed.